### PR TITLE
GHC v8.1 renamed 'cmpType' to 'nonDetCmpType'

### DIFF
--- a/src/GHC/Extra/Instances.hs
+++ b/src/GHC/Extra/Instances.hs
@@ -10,10 +10,13 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+#if __GLASGOW_HASKELL__ < 801
+#define nonDetCmpType cmpType
+#endif
 
 module GHC.Extra.Instances where
 
-import Type (Type,cmpType)
+import Type (Type,nonDetCmpType)
 #if __GLASGOW_HASKELL__ >= 711
 import Type (eqType)
 #endif
@@ -24,4 +27,4 @@ instance Eq Type where
 #endif
 
 instance Ord Type where
-  compare = cmpType
+  compare = nonDetCmpType


### PR DESCRIPTION
See my comment
https://github.com/clash-lang/ghc-typelits-natnormalise/commit/84a3a5e13f2e7dad1aac1db9ab1d887635612fb4#commitcomment-18543431

I am building with GHC 8.1 so I can spot upstream problems...