### PR TITLE
cabal: fix a warning with cabal new-build

### DIFF
--- a/ghc-typelits-natnormalise.cabal
+++ b/ghc-typelits-natnormalise.cabal
@@ -82,7 +82,7 @@ test-suite test-ghc-typelits-natnormalise
   main-is:             Tests.hs
   Other-Modules:       ErrorTests
   build-depends:       base >=4.8 && <5,
-                       ghc-typelits-natnormalise >= 0.4,
+                       ghc-typelits-natnormalise,
                        tasty >= 0.10,
                        tasty-hunit >= 0.9,
                        template-haskell >= 2.11.0.0


### PR DESCRIPTION
`new-build` says:

    Configuring library for ghc-typelits-natnormalise-0.5.3..
    Warning: The package has an extraneous version range for a dependency on an
    internal library: ghc-typelits-natnormalise >=0.4. This version range
    includes the current package but isn't needed as the current package's
    library will always be used.