### PR TITLE
Supports the released version of GHC-8.4.1

### DIFF
--- a/src/GHC/TypeLits/Normalise.hs
+++ b/src/GHC/TypeLits/Normalise.hs
@@ -291,14 +291,14 @@ unifyItemToPredType ui =
 evMagic :: Ct -> [PredType] -> TcPluginM (Maybe ((EvTerm, Ct), [Ct]))
 evMagic ct preds = case classifyPredType $ ctEvPred $ ctEvidence ct of
   EqPred NomEq t1 t2 -> do
-#if MIN_VERSION_ghc(8,5,0)
+#if MIN_VERSION_ghc(8,4,1)
     holes <- mapM (newCoercionHole . uncurry mkPrimEqPred . getEqPredTys) preds
 #else
     holes <- replicateM (length preds) newCoercionHole
 #endif
     let newWanted = zipWith (unifyItemToCt (ctLoc ct)) preds holes
         ctEv      = mkUnivCo (PluginProv "ghc-typelits-natnormalise") Nominal t1 t2
-#if MIN_VERSION_ghc(8,5,0)
+#if MIN_VERSION_ghc(8,4,1)
         holeEvs   = map mkHoleCo holes
 #else
         holeEvs   = zipWith (\h p -> uncurry (mkHoleCo h Nominal) (getEqPredTys p)) holes preds


### PR DESCRIPTION
Hackage's `ghc-typelits-natnormalise` fails to compile with GHC-8.4.1.
Fortunately, lowering `MIN_VERSION_ghc(8,5,0)` to `MIN_VERSION_ghc(8,4,1)` fixes this.