### PR TITLE
Auto-casting dictionaries for general (i.e. not equality) constraints

### DIFF
--- a/ghc-typelits-natnormalise.cabal
+++ b/ghc-typelits-natnormalise.cabal
@@ -70,6 +70,7 @@ library
                        ghc                 >=8.0.1 && <8.9,
                        ghc-tcplugins-extra >=0.3,
                        integer-gmp         >=1.0   && <1.1,
+                       syb,
                        transformers        >=0.5.2.0 && < 0.6
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/ghc-typelits-natnormalise.cabal
+++ b/ghc-typelits-natnormalise.cabal
@@ -70,7 +70,7 @@ library
                        ghc                 >=8.0.1 && <8.9,
                        ghc-tcplugins-extra >=0.3,
                        integer-gmp         >=1.0   && <1.1,
-                       syb,
+                       syb                 >=0.7.1 && <0.8,
                        transformers        >=0.5.2.0 && < 0.6
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/GHC/TypeLits/Normalise.hs
+++ b/src/GHC/TypeLits/Normalise.hs
@@ -271,21 +271,22 @@ decideEqualSOP
 -- to its normal form @Show (Foo (2 + n))@, which is eventually
 -- useful in solving phase.
 decideEqualSOP opts gen'd givens _deriveds [] = do
-    done <- tcPluginIO $ readIORef gen'd
-#if MIN_VERSION_ghc(8,4,0)
-    let simplGivens = flattenGivens givens
-#else
-    simplGivens <- mapM zonkCt givens
-#endif
-    let reds =
-          filter (\(_,(_,_,v)) -> null v || negNumbers opts) $
-          reduceGivens opts done simplGivens
-        newlyDone = map (\(_,(prd, _,_)) -> CType prd) reds
-    tcPluginIO $
-      modifyIORef' gen'd $ union (fromList newlyDone)
-    newGivens <- forM reds $ \(origCt, (pred', evTerm, _)) ->
-      mkNonCanonical' (ctLoc origCt) <$> newGiven (ctLoc origCt) pred' evTerm
-    return (TcPluginOk [] newGivens)
+--     done <- tcPluginIO $ readIORef gen'd
+-- #if MIN_VERSION_ghc(8,4,0)
+--     let simplGivens = flattenGivens givens
+-- #else
+--     simplGivens <- mapM zonkCt givens
+-- #endif
+--     let reds =
+--           filter (\(_,(_,_,v)) -> null v || negNumbers opts) $
+--           reduceGivens opts done simplGivens
+--         newlyDone = map (\(_,(prd, _,_)) -> CType prd) reds
+--     tcPluginIO $
+--       modifyIORef' gen'd $ union (fromList newlyDone)
+--     newGivens <- forM reds $ \(origCt, (pred', evTerm, _)) ->
+--       mkNonCanonical' (ctLoc origCt) <$> newGiven (ctLoc origCt) pred' evTerm
+--     return (TcPluginOk [] newGivens)
+  return (TcPluginOk [] [])
 
 -- Solving phase.
 -- Solves in/equalities on Nats and simplifiable constraints
@@ -298,7 +299,7 @@ decideEqualSOP opts gen'd givens  _deriveds wanteds = do
         wanteds0 = map (\ct -> (OrigCt ct,
                                 TcPluginM.substCt subst ct
                                 )
-                       ) $ flattenGivens wanteds
+                       ) wanteds
 #else
     let wanteds0 = map (\ct -> (OrigCt ct, ct)) wanteds
     simplGivens <- mapM zonkCt givens

--- a/src/GHC/TypeLits/Normalise.hs
+++ b/src/GHC/TypeLits/Normalise.hs
@@ -277,7 +277,7 @@ decideEqualSOP opts gen'd givens _deriveds [] = do
     simplGivens <- mapM zonkCt givens
 #endif
     let reds =
-          filter (\(_,(_,_,v)) -> null v ) $
+          filter (\(_,(_,_,v)) -> null v || negNumbers opts) $
           reduceGivens opts done simplGivens
         newlyDone = map (\(_,(prd, _,_)) -> CType prd) reds
     tcPluginIO $

--- a/src/GHC/TypeLits/Normalise.hs
+++ b/src/GHC/TypeLits/Normalise.hs
@@ -335,8 +335,7 @@ tryReduceGiven opts simplGivens ct = do
         ws' = subToPred opts ws
     guard $
       all (\(p,_) ->
-         any ((`eqType` p). ctEvPred . ctEvidence)
-          simplGivens
+         any ((`eqType` p). ctEvPred . ctEvidence) simplGivens
           -- TODO: use solveIneq and solveIneqInstant here
       ) ws'
 

--- a/src/GHC/TypeLits/Normalise.hs
+++ b/src/GHC/TypeLits/Normalise.hs
@@ -270,6 +270,11 @@ decideEqualSOP
 -- we can reduce given constraints like @Show (Foo (n + 2))@
 -- to its normal form @Show (Foo (2 + n))@, which is eventually
 -- useful in solving phase.
+--
+-- This helps us to solve /indirect/ constraints;
+-- without this phase, we cannot derive, e.g.,
+-- @IsVector UVector (Fin (n + 1))@ from
+-- @Unbox (1 + n)@!
 decideEqualSOP opts gen'd givens _deriveds [] = do
     done <- tcPluginIO $ readIORef gen'd
 #if MIN_VERSION_ghc(8,4,0)

--- a/src/GHC/TypeLits/Normalise.hs
+++ b/src/GHC/TypeLits/Normalise.hs
@@ -539,6 +539,7 @@ evMagic ct knW preds = case classifyPredType $ ctEvPred $ ctEvidence ct of
 #if MIN_VERSION_ghc(8,4,1)
         holeEvs   = map mkHoleCo holes
 #else
+        predTypes = map fst preds
         holeEvs   = zipWith (\h p -> uncurry (mkHoleCo h Nominal) (getEqPredTys p)) holes predTypes
 #endif
     forallEv <- mkForAllCos <$> mapM mkCoVar predKinds <*> pure ctEv

--- a/src/GHC/TypeLits/Normalise.hs
+++ b/src/GHC/TypeLits/Normalise.hs
@@ -271,22 +271,21 @@ decideEqualSOP
 -- to its normal form @Show (Foo (2 + n))@, which is eventually
 -- useful in solving phase.
 decideEqualSOP opts gen'd givens _deriveds [] = do
---     done <- tcPluginIO $ readIORef gen'd
--- #if MIN_VERSION_ghc(8,4,0)
---     let simplGivens = flattenGivens givens
--- #else
---     simplGivens <- mapM zonkCt givens
--- #endif
---     let reds =
---           filter (\(_,(_,_,v)) -> null v || negNumbers opts) $
---           reduceGivens opts done simplGivens
---         newlyDone = map (\(_,(prd, _,_)) -> CType prd) reds
---     tcPluginIO $
---       modifyIORef' gen'd $ union (fromList newlyDone)
---     newGivens <- forM reds $ \(origCt, (pred', evTerm, _)) ->
---       mkNonCanonical' (ctLoc origCt) <$> newGiven (ctLoc origCt) pred' evTerm
---     return (TcPluginOk [] newGivens)
-  return (TcPluginOk [] [])
+    done <- tcPluginIO $ readIORef gen'd
+#if MIN_VERSION_ghc(8,4,0)
+    let simplGivens = flattenGivens givens
+#else
+    simplGivens <- mapM zonkCt givens
+#endif
+    let reds =
+          filter (\(_,(_,_,v)) -> null v || negNumbers opts) $
+          reduceGivens opts done simplGivens
+        newlyDone = map (\(_,(prd, _,_)) -> CType prd) reds
+    tcPluginIO $
+      modifyIORef' gen'd $ union (fromList newlyDone)
+    newGivens <- forM reds $ \(origCt, (pred', evTerm, _)) ->
+      mkNonCanonical' (ctLoc origCt) <$> newGiven (ctLoc origCt) pred' evTerm
+    return (TcPluginOk [] newGivens)
 
 -- Solving phase.
 -- Solves in/equalities on Nats and simplifiable constraints

--- a/src/GHC/TypeLits/Normalise.hs
+++ b/src/GHC/TypeLits/Normalise.hs
@@ -333,7 +333,6 @@ tryReduceGiven opts simplGivens ct = do
           runWriter $ normaliseNatEverywhere $
           ctEvPred $ ctEvidence ct
         ws' = subToPred opts ws
-        ineqs = 
     guard $
       all (\(p,_) ->
          any ((`eqType` p). ctEvPred . ctEvidence)

--- a/src/GHC/TypeLits/Normalise/SOP.hs
+++ b/src/GHC/TypeLits/Normalise/SOP.hs
@@ -85,6 +85,7 @@ module GHC.TypeLits.Normalise.SOP
   , mergeSOPAdd
   , mergeSOPMul
   , normaliseExp
+  , simplifySOP
   )
 where
 

--- a/src/GHC/TypeLits/Normalise/Unify.hs
+++ b/src/GHC/TypeLits/Normalise/Unify.hs
@@ -53,7 +53,7 @@ import Data.Function (on)
 import Data.List     ((\\), intersect, mapAccumL, nub)
 import Data.Maybe    (fromMaybe, mapMaybe)
 import Data.Set      (Set)
-import Data.Generics
+import Data.Generics (mkM, everywhereM)
 import qualified Data.Set as Set
 
 import GHC.Base               (isTrue#,(==#))
@@ -128,7 +128,7 @@ normaliseNatEverywhere ty
   | otherwise = do
       ty' <- everywhereM (mkM normaliseSimplifyNat) ty
       return $ if ty `eqType` ty' then Nothing else Just ty'
-      
+
 normaliseSimplifyNat :: Type -> Writer [(Type, Type)] Type
 normaliseSimplifyNat ty
   | typeKind ty `eqType` typeNatKind = do
@@ -262,11 +262,11 @@ subtractionToPred (x,y) =
 -- made, for use when turning the substitution back into constraints.
 type CoreUnify = UnifyItem TyVar CType
 
-data UnifyItem v c = SubstItem { siVar  :: v
-                               , siSOP  :: SOP v c
+data UnifyItem v c = SubstItem { siVar :: v
+                               , siSOP :: SOP v c
                                }
-                   | UnifyItem { siLHS  :: SOP v c
-                               , siRHS  :: SOP v c
+                   | UnifyItem { siLHS :: SOP v c
+                               , siRHS :: SOP v c
                                }
   deriving Eq
 
@@ -451,13 +451,13 @@ unifiers' ct (S [p2]) (S [P [E s1 p1]]) = case collectBases p2 of
 -- Where 'a' is a variable, 'i' and 'j' are integer literals, and j `mod` i == 0
 unifiers' ct (S [P ((I i):ps)]) (S [P [I j]]) =
   case safeDiv j i of
-    Just k  -> unifiers' ct (S [P ps]) (S [P [I k]])
-    _       -> []
+    Just k -> unifiers' ct (S [P ps]) (S [P [I k]])
+    _      -> []
 
 unifiers' ct (S [P [I j]]) (S [P ((I i):ps)]) =
   case safeDiv j i of
-    Just k  -> unifiers' ct (S [P ps]) (S [P [I k]])
-    _       -> []
+    Just k -> unifiers' ct (S [P ps]) (S [P [I k]])
+    _      -> []
 
 -- (2*a) ~ (2*b) ==> [a := b]
 -- unifiers' ct (S [P (p:ps1)]) (S [P (p':ps2)])
@@ -490,9 +490,9 @@ unifiers' ct s1@(S ps1) s2@(S ps2) = case sopToIneq k1 of
   _ | null psx
     , length ps1 == length ps2
     -> case nub (concat (zipWith (\x y -> unifiers' ct (S [x]) (S [y])) ps1 ps2)) of
-        []  -> unifiers'' ct (S ps1) (S ps2)
+        []                             -> unifiers'' ct (S ps1) (S ps2)
         [k] | length ps1 == length ps2 -> [k]
-        _   -> []
+        _                              -> []
     | null psx
     , isGiven (ctEvidence ct)
     -> unifiers'' ct (S ps1) (S ps2)

--- a/tests/ErrorTests.hs
+++ b/tests/ErrorTests.hs
@@ -208,6 +208,3 @@ test17Errors =
           then litE $ stringL "Couldn't match type ‘1 <=? n’ with ‘'True’"
           else litE $ stringL "Couldn't match type `1 <=? n' with 'True"
     )]
-
-test18 :: Dict (Eq (Boo n)) -> Dict (Eq (Boo (n + 1)))
-test18 Dict = Dict

--- a/tests/ErrorTests.hs
+++ b/tests/ErrorTests.hs
@@ -20,7 +20,6 @@ module ErrorTests where
 
 import Data.Proxy
 import GHC.TypeLits
-import Unsafe.Coerce
 
 import GHC.IO.Encoding            (getLocaleEncoding, textEncodingName, utf8)
 import Language.Haskell.TH        (litE, stringL)

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP                 #-}
+{-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
@@ -400,6 +401,14 @@ instance Show (AtMost n) where
 
 succAtMost :: AtMost n -> AtMost (n + 1)
 succAtMost (AtMost (Proxy :: Proxy a)) = AtMost (Proxy :: Proxy a)
+
+data Dict c where
+  Dict :: c => Dict c
+data Boo (n :: Nat)
+eqReducePM
+  :: Eq (Boo (n + 2))
+  => Dict (Eq (Boo ((n + 1) + 1)))
+eqReducePM = Dict
 
 main :: IO ()
 main = defaultMain tests

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -412,21 +412,10 @@ eqReduceForwardMinusPlus
   => Dict (Eq (Boo (n - 1 + 2)))
 eqReduceForwardMinusPlus = Dict
 
--- This fails  because
---  1 <= m + 2 
--- is unknown at simplification phase
--- and we cannot create @Wanted@s during
--- the simplification!
--- Perhaps we can still overcome this situation
--- by implementing something like @isTrivialEqn@ or so.
---
--- Alas! It fails even given with inequality!
--- Perhaps we should use @toNatEquality@ to lookup 
--- and/or generating appropriate inequalities from givens.
-{- eqReduceBackward
-  :: (Eq (Boo (m + 2 - 1)), (1 <=? m + 2) ~ 'True)
+eqReduceBackward
+  :: (Eq (Boo (m + 2 - 1)))
   => Dict (Eq (Boo (m + 1)))
-eqReduceBackward = Dict -}
+eqReduceBackward = Dict
 
 eqReduceBackward'
   :: (Eq (Boo (1 + m + 2)))

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -576,16 +576,21 @@ predFin FZ      = FZ
 showSucPred :: KnownNat (n + 2) => Fin (n + 2) -> String
 showSucPred = showFin .  FS . predFin
 
-class Up env n where
+class Up env (n :: Nat) where
   up :: env -> Fin n -> Fin (n + 1)
 
-class Down env n where
+class Down env (n :: Nat) where
   down :: env -> Fin n -> Fin (n - 1)
 
-class ShowWith env n where
+class ShowWith env (n :: Nat) where
   showWith :: env -> Fin n -> String
 
 showDownUp
   :: (Up env n, Down env (n + 1), ShowWith env n)
   => env -> Fin n -> String
 showDownUp env fn = showWith env $ down env $ up env fn
+
+showDownUp'
+  :: (Up env n, Down env (n + 1), KnownNat n)
+  => env -> Fin n -> String
+showDownUp' env fn = showFin $ down env $ up env fn

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE MultiParamTypeClasses     #-}
 {-# LANGUAGE NoImplicitPrelude         #-}
 {-# LANGUAGE PolyKinds                 #-}
 {-# LANGUAGE Rank2Types                #-}
@@ -574,3 +575,17 @@ predFin FZ      = FZ
 
 showSucPred :: KnownNat (n + 2) => Fin (n + 2) -> String
 showSucPred = showFin .  FS . predFin
+
+class Up env n where
+  up :: env -> Fin n -> Fin (n + 1)
+
+class Down env n where
+  down :: env -> Fin n -> Fin (n - 1)
+
+class ShowWith env n where
+  showWith :: env -> Fin n -> String
+
+showDownUp
+  :: (Up env n, Down env (n + 1), ShowWith env n)
+  => env -> Fin n -> String
+showDownUp env fn = showWith env $ down env $ up env fn

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -407,7 +407,7 @@ data Dict c where
 data Boo (n :: Nat)
 eqReducePM
   :: Eq (Boo (n + 2))
-  => Dict (Eq (Boo ((n + 1) + 1)))
+  => Dict (Eq (Boo (n + 1 + 1)))
 eqReducePM = Dict
 
 main :: IO ()

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -18,6 +18,7 @@
 #endif
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise #-}
+{-# OPTIONS_GHC -dcore-lint #-}
 
 import GHC.TypeLits
 import Unsafe.Coerce

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -548,8 +548,6 @@ tests = testGroup "ghc-typelits-natnormalise"
       , testCase "2a <=? 4a ~ False" $ testProxy14 `throws` testProxy14Errors
       , testCase "Eq (Boo n) => Eq (Boo (n - 1 + 1))" $
           testProxy17 `throws` test17Errors
-      , testCase "Eq (Boo n) => Eq (Boo (n + 1))" $
-          test18 (maliciousEqBoo (Proxy :: Proxy 7)) `throws` test17Errors
       ]
     ]
   ]

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -546,8 +546,10 @@ tests = testGroup "ghc-typelits-natnormalise"
       , testCase "() => (a+b <= a+c)" $ testProxy12 `throws` testProxy12Errors
       , testCase "4a <= 2a" $ testProxy13 `throws` testProxy13Errors
       , testCase "2a <=? 4a ~ False" $ testProxy14 `throws` testProxy14Errors
-      , testCase "Eq (Boo n) => Eq (Boo (n - 1 + 1))" $
+      , testCase "Show (Boo n) => Show (Boo (n - 1 + 1))" $
           testProxy17 `throws` test17Errors
+      , testCase "Show (Boo n) => Show (Boo (n + 1))" $
+          testProxy18 `throws` test18Errors
       ]
     ]
   ]

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,18 +1,19 @@
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE TypeOperators       #-}
-{-# LANGUAGE NoImplicitPrelude   #-}
-{-# LANGUAGE Rank2Types          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE CPP                       #-}
+{-# LANGUAGE ConstraintKinds           #-}
+{-# LANGUAGE DataKinds                 #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE NoImplicitPrelude         #-}
+{-# LANGUAGE PolyKinds                 #-}
+{-# LANGUAGE Rank2Types                #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE TypeOperators             #-}
 
 #if __GLASGOW_HASKELL__ >= 805
-{-# LANGUAGE NoStarIsType #-}
+{-# LANGUAGE NoStarIsType              #-}
 #endif
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise #-}
@@ -130,7 +131,7 @@ tail' = tail
 -- >>> init (1:>2:>3:>Nil)
 -- <1,2>
 init :: Vec (n + 1) a -> Vec n a
-init (_ :> Nil)      = Nil
+init (_ :> Nil)     = Nil
 init (x :> y :> ys) = x :> init (y :> ys)
 
 init' :: (1 <= m) => Vec m a -> Vec (m-1) a
@@ -555,3 +556,21 @@ throws v xs = do
       if all (`isInfixOf` msg) xs
          then return ()
          else assertFailure msg
+
+showFin :: forall n. KnownNat n => Fin n -> String
+showFin f = mconcat [
+  show (finToInt f)
+  , "/"
+  , show (natVal (Proxy :: Proxy n))
+  ]
+
+finToInt :: Fin n -> Int
+finToInt FZ      = 0
+finToInt (FS fn) = finToInt fn + 1
+
+predFin :: Fin (n + 2) -> Fin (n + 1)
+predFin (FS fn) = fn
+predFin FZ      = FZ
+
+showSucPred :: KnownNat (n + 2) => Fin (n + 2) -> String
+showSucPred = showFin .  FS . predFin


### PR DESCRIPTION
Motivation
========

Suppose we have the following:

```hs
data Fin (n :: Nat) where
  FZ :: Fin (n + 1)
  FS :: F n -> F (n + 1)

showFin :: forall n. KnownNat n => Fin n -> String
showFin f = mconcat [
  show (finToInt f)
  , "/"
  , show (natVal (Proxy :: Proxy n))
  ]

finToInt :: Fin n -> Int
finToInt FZ      = 0
finToInt (FS fn) = finToInt fn + 1

predFin :: Fin (n + 2) -> Fin (n + 1)
predFin (FS fn) = fn
predFin FZ      = FZ
```

So `Fin` is just the type of finite ordinals, borrowed from `ErrorTest.hs` in test case.
Consider the following trivial `show` function:

```hs
showSucPred :: KnownNat (n + 2) => Fin (n + 2) -> String
showSucPred = showFin .  FS . predFin
```

At first glance, this must compile. But, GHC complains as follows:

```hs
ghc-typelits-natnormalise/tests/Tests.hs:576:15: error:
    • Could not deduce (KnownNat ((n + 1) + 1))
        arising from a use of ‘showFin’
      from the context: KnownNat (n + 2)
        bound by the type signature for:
                   showSucPred :: forall (n :: Nat).
                                  KnownNat (n + 2) =>
                                  Fin (n + 2) -> String
        at tests/Tests.hs:575:1-56
    • In the first argument of ‘(.)’, namely ‘showFin’
      In the expression: showFin . FS . predFin
      In an equation for ‘showSucPred’:
          showSucPred = showFin . FS . predFin
    |       
576 | showSucPred = showFin .  FS . predFin
```

This to get this compile, we had to explicitly specify the "argument" type, which invokes type-equality constraint solving, which the current `ghc-typelits-natnormalise` could treat it properly:

```hs
showSucPred :: KnownNat (n + 2) => Fin (n + 2) -> String
showSucPred = showFin @(n + 2) .  FS . predFin
```

Solution
======

This pull request remedies the cases like above.
Intuitively, the algorithm does the following thing:

1. Find wanted constraints, which are not necessarily (in/equality), containing *reducible* type-level naturals. (by `simplifySOP` and `normaliseNat`).
  In above example: `KnownNat (n + 1 + 1)` can be reduced to `KnownNat (n + 2)`.
2. Mark such wanteds as *solved*, just casting the dictionary of reduced constraints; in above we can  use `KnownNat (n + 2)` coerced to `KnownNat (n + 1 + 1)`.
  If reduced dictionaries are available as `[G]`ivens, we just use it; otherwise we `[W]`ant it.
  We also `[W]`ant inequalities needed for subtractions if needed.

But the above strategy cannot derive dictionary from *non-reduced* dictionaries, e.g. `KnownNat (n + 2)` from `KnownNat (n + 1 + 1)`.
So, we actually try to reduce `[G]`iven constraints as well.
This is done twice: in the simplification phase and at the beginning of solving phase.
Ideally, we can just do it only in simplification phase.
However, if one wants to reduce [G]ivens with subtraction, one has to lookup givens for inequality or request them as new [W]antends.
Unfortunately, we cannot request new [W]anteds in simplification phase in the current GHC.
So, we reduce constraints also in reduction phase.
Still, simplification phase can generate useful givens that can save further constraint solving, so we just do that twice.
