### PR TITLE
Only claim contradiction given empty predicates

### DIFF
--- a/src/GHC/TypeLits/Normalise.hs
+++ b/src/GHC/TypeLits/Normalise.hs
@@ -485,8 +485,8 @@ simplifyNats opts@Opts {..} eqsG eqsW =
           evs' <- maybe evs (:evs) <$> evMagic ct knW (subToPred opts k)
           simples subst evs' leqsG' xs eqs'
 
-        Just (False,_) -> return (Impossible (fst eq))
-        Nothing
+        Just (False,_) | null k -> return (Impossible (fst eq))
+        _
           -- This inequality is either a given constraint, or it is a wanted
           -- constraint, which in normal form is equal to another given
           -- constraint, hence it can be solved.


### PR DESCRIPTION
Some of the predicates might be absurd, like `CLog 2 9 <= 1`;
sadly the API doesn't allow us to check whether these predicates
are absurd when we want to claim contradiction. So we must only
claim contradiction when there are no predicates to this claim.

Solves https://github.com/clash-lang/clash-compiler/issues/929