### PR TITLE
Don't emit reduced wanteds

### DIFF
--- a/tests/ErrorTests.hs
+++ b/tests/ErrorTests.hs
@@ -208,19 +208,6 @@ test17Errors =
           else litE $ stringL "Couldn't match type `1 <=? n' with 'True"
     )]
 
-test18 :: Show (Boo n) => Proxy n -> Boo (n + 1) -> String
-test18 = const show
-
-testProxy18 :: String
-testProxy18 = test18 (Proxy :: Proxy 7) Boo
-
-test18Errors =
-  [$(do localeEncoding <- runIO (getLocaleEncoding)
-        if textEncodingName localeEncoding == textEncodingName utf8
-          then litE $ stringL "Could not deduce (Show (Boo (1 + n))) arising from a use of ‘show’"
-          else litE $ stringL "Could not deduce (Show (Boo (1 + n))) arising from a use of `show'"
-    )]
-
 test19f :: (1 <= n)
   => Proxy n -> Proxy n
 test19f = id

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -542,8 +542,6 @@ tests = testGroup "ghc-typelits-natnormalise"
       , testCase "2a <=? 4a ~ False" $ testProxy14 `throws` testProxy14Errors
       , testCase "Show (Boo n) => Show (Boo (n - 1 + 1))" $
           testProxy17 `throws` test17Errors
-      , testCase "Show (Boo n) => Show (Boo (n + 1))" $
-          testProxy18 `throws` test18Errors
       , testCase "1 <= m, m <= rp implies 1 <= rp - m" $ (testProxy19 (Proxy @ 1) (Proxy @ 1)) `throws` test19Errors
       ]
     ]


### PR DESCRIPTION
i.e. Don't solve `[W] F (n + 1)` by returning `[W] F (1 + n) |> F (n + 1)` as evidence and emitting
a new `[W] F (1 + n)` constraint. This can sometimes throw us into a constraint-solver loop where GHC asks us to up the constraint-solver-iteration limit.