### PR TITLE
`1 <= n` only implies `1 <= n + F n` when `KnownNat (F n)`

### DIFF
--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -427,6 +427,18 @@ eqReduceBackward'
   => Dict (Eq (Boo (m + 3)))
 eqReduceBackward' = Dict
 
+proxyInEq8fun
+  :: (1 <= (n + CLog 2 n))
+  => Proxy n
+  -> Proxy n
+proxyInEq8fun = id
+
+proxyInEq8
+  :: (1 <= n, KnownNat (CLog 2 n))
+  => Proxy n
+  -> Proxy n
+proxyInEq8 = proxyInEq8fun
+
 main :: IO ()
 main = defaultMain tests
 
@@ -520,6 +532,9 @@ tests = testGroup "ghc-typelits-natnormalise"
       "Proxy"
     , testCase "1 <= G a implies F a <= G a * F a" $
       show (proxyInEqImplication4 (Proxy :: Proxy 2)) @?=
+      "Proxy"
+    , testCase "`(1 <= n)` only implies `(1 <= n + F n)` when `KnownNat (F n)`" $
+      show (proxyInEq8 (Proxy :: Proxy 2)) @?=
       "Proxy"
     ]
   , testGroup "errors"


### PR DESCRIPTION
i.e. we only discharge the `1 <= n + F n` inequality given the `1 <= n` inequality when `F n` actually resolves to a Natural number. e.g. when `F n` is defined as:

```haskell
type family F n where
  F 2 = 1
  F n = n - 8
```

then solving `1 <= 4 + F 4` from simply knowing `1 <= 4` would be incorrect. Given that `1 <= 4 + F 4` resolves to `1 <= 0`, which is not correct.