### PR TITLE
Derive `KnownNat a ~ KnownNat (((a - b) + c) + (b - c)))`

### DIFF
--- a/ghc-typelits-natnormalise.cabal
+++ b/ghc-typelits-natnormalise.cabal
@@ -70,7 +70,6 @@ library
                        ghc                 >=8.0.1 && <8.11,
                        ghc-tcplugins-extra >=0.3.1,
                        integer-gmp         >=1.0   && <1.1,
-                       syb                 >=0.7.1 && <0.8,
                        transformers        >=0.5.2.0 && < 0.6
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/GHC/TypeLits/Normalise.hs
+++ b/src/GHC/TypeLits/Normalise.hs
@@ -479,11 +479,13 @@ simplifyNats opts@Opts {..} eqsG eqsW = do
       _  -> do
         tcPluginTrace ("simplifyNats(backtrack: " ++ show (length fancyGivens) ++ ")")
                       (ppr varEqs)
-        foldr findFirstSimpliedWanted (Simplified []) <$>
-              mapM (\v -> do let eqs = v ++ eqsW
-                             tcPluginTrace "simplifyNats" (ppr eqs)
-                             simples [] [] [] [] eqs)
-              fancyGivens
+
+        allSimplified <- forM fancyGivens $ \v -> do
+          let eqs = v ++ eqsW
+          tcPluginTrace "simplifyNats" (ppr eqs)
+          simples [] [] [] [] eqs
+
+        pure (foldr findFirstSimpliedWanted (Simplified []) allSimplified)
   where
     simples :: [CoreUnify]
             -> [((EvTerm, Ct), [Ct])]

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -340,6 +340,25 @@ proxyEq3
   -> Proxy x
 proxyEq3 _ _ x = x
 
+-- Would yield (b <=? c) ~ 'True
+proxyEq4
+  :: forall a b c
+   . (KnownNat a, c <= b, b <= a)
+  => Proxy b
+  -> Proxy c
+  -> Proxy a
+  -> Proxy (((a - b) + c) + (b - c))
+proxyEq4 = theProxy
+ where
+  theProxy
+    :: forall a b c
+     . (KnownNat (((a - b) + c) + (b - c)), c <= b, b <= a)
+    => Proxy b
+    -> Proxy c
+    -> Proxy a
+    -> Proxy (((a - b) + c) + (b - c))
+  theProxy _ _ = id
+
 proxyInEqImplication :: (2 <= (2 ^ (n + d)))
   => Proxy d
   -> Proxy n


### PR DESCRIPTION
```
'normaliseNatEverywhere' would use 'everywhereM' to walk types and
simplify nats anywhere in it. Because 'everywhereM' doesn't
differentiate between type constructors 'normaliseNat' understands
(i.e., -, +, *, ^) it would also run it on every subexpression.
'normaliseNat' would then yield spurious results it wouldn't have,
if only it had seen the bigger picture..
```