### PR TITLE
Solve unflattened wanteds instead of wanteds passed to plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for the [`ghc-typelits-natnormalise`](http://hackage.haskell.org/package/ghc-typelits-natnormalise) package
 
+## Unreleased
+* Solve unflattened wanteds instead of the wanteds passed to the plugin. Fixes [#1901]https://github.com/clash-lang/clash-compiler/issues/1901.
+
 ## 0.7.6 *June 20th 2021*
 * Do not vacuously solve `forall a b . 1 <=? a^b ~ True`
 * Do not solve constraints within `KnownNat`, leave that to https://hackage.haskell.org/package/ghc-typelits-knonwnnat

--- a/ghc-typelits-natnormalise.cabal
+++ b/ghc-typelits-natnormalise.cabal
@@ -1,5 +1,5 @@
 name:                ghc-typelits-natnormalise
-version:             0.7.6
+version:             0.7.7
 synopsis:            GHC typechecker plugin for types of kind GHC.TypeLits.Nat
 description:
   A type checker plugin for GHC that can solve /equalities/ and /inequalities/

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -477,6 +477,27 @@ proxyInEq8
   -> Proxy n
 proxyInEq8 = proxyInEq8fun
 
+data H2 = H2 { p :: Nat }
+
+class Q (dom :: Symbol) where
+  type G2 dom :: H2
+
+type family P (c :: H2) :: Nat where
+  P ('H2 p) = p
+
+type F2 (dom :: Symbol) = P (G2 dom)
+
+type Dom = "System"
+
+instance Q Dom where
+  type G2 Dom = 'H2 2
+
+tyFamMonotonicityFun :: (1 <= F2 dom) => Proxy (dom :: Symbol) -> ()
+tyFamMonotonicityFun _ = ()
+
+tyFamMonotonicity :: (2 <= F2 dom) => Proxy (dom :: Symbol) -> ()
+tyFamMonotonicity dom = tyFamMonotonicityFun dom
+
 main :: IO ()
 main = defaultMain tests
 
@@ -574,6 +595,9 @@ tests = testGroup "ghc-typelits-natnormalise"
     , testCase "`(1 <= n)` only implies `(1 <= n + F n)` when `KnownNat (F n)`" $
       show (proxyInEq8 (Proxy :: Proxy 2)) @?=
       "Proxy"
+    , testCase "2 <= P (G2 dom) implies 1 <= P (G2 dom)" $
+      show (tyFamMonotonicity (Proxy :: Proxy Dom)) @?=
+      "()"
     ]
   , testGroup "errors"
     [ testCase "x + 2 ~ 3 + x" $ testProxy1 `throws` testProxy1Errors


### PR DESCRIPTION
Flattened wanteds where not used in the nat eqquality solver.  Now instead the unflattened wanteds are replaced by the flattened wanteds.

TODO:
- [x] Build Clash-prelude to check for regressions.
- [x] Build Clash-cores and see if it solves the original issue.