### PR TITLE
Use TemplateHaskellQuotes for Name lookup

### DIFF
--- a/ghc-typelits-natnormalise.cabal
+++ b/ghc-typelits-natnormalise.cabal
@@ -78,8 +78,9 @@ library
   hs-source-dirs:      src
   if impl(ghc >= 8.0) && impl(ghc < 9.4)
     hs-source-dirs:    src-pre-ghc-9.4
-  if impl(ghc >= 9.4) && impl(ghc < 9.10)
+  if impl(ghc >= 9.4) && impl(ghc < 9.12)
     hs-source-dirs:    src-ghc-9.4
+    build-depends:     template-haskell    >=2.17 && <2.22
   default-language:    Haskell2010
   other-extensions:    CPP
                        LambdaCase


### PR DESCRIPTION
Adds support for GHC 9.10 by making name resolution less dependent upon the internal structure of `base`.