### PR TITLE
Do not pass `deps` to `mkUnivCo`

### DIFF
--- a/src-ghc-9.12/GHC/TypeLits/Normalise.hs
+++ b/src-ghc-9.12/GHC/TypeLits/Normalise.hs
@@ -706,17 +706,17 @@ evSubtPreds :: CtLoc -> [PredType] -> TcPluginM [Ct]
 evSubtPreds loc = mapM (fmap mkNonCanonical . newWanted loc)
 
 evMagic :: Ct -> [Coercion] -> Set CType -> [PredType] -> TcPluginM (Maybe ((EvTerm, Ct), [Ct]))
-evMagic ct deps knW preds = do
+evMagic ct _deps knW preds = do
   holeWanteds <- evSubtPreds (ctLoc ct) preds
   knWanted <- mapM (mkKnWanted (ctLoc ct)) (toList knW)
   let newWant = knWanted ++ holeWanteds
   case classifyPredType $ ctEvPred $ ctEvidence ct of
     EqPred NomEq t1 t2 ->
-      let ctEv = mkUnivCo (PluginProv "ghc-typelits-natnormalise") deps Nominal t1 t2
+      let ctEv = mkUnivCo (PluginProv "ghc-typelits-natnormalise") [] Nominal t1 t2
       in return (Just ((EvExpr (Coercion ctEv), ct),newWant))
     IrredPred p ->
       let t1 = mkTyConApp (cTupleTyCon 0) []
-          co = mkUnivCo (PluginProv "ghc-typelits-natnormalise") deps Representational t1 p
+          co = mkUnivCo (PluginProv "ghc-typelits-natnormalise") [] Representational t1 p
           dcApp = evId (dataConWrapId (cTupleDataCon 0))
        in return (Just ((evCast dcApp co, ct),newWant))
     _ -> return Nothing


### PR DESCRIPTION
Causes GHC load issues for Clash, while seemingly not contributing to anything else?

----------------

Before this I got an error when [upgrading Clash to GHC 9.12](https://github.com/clash-lang/clash-compiler/pull/2941):

```
                /home/martijn/code/clash-compiler/dist-newstyle/build/x86_64-linux/ghc-9.12.2/clash-prelude-1.9.0/build/Clash/Sized/Vector.hi
                Declaration for select
                Unfolding of select:
                  Iface id out of scope:  ipv
                  env: [ESg3Y :-> ds, ESg3Z :-> wild, ESgcH :-> wild1,
                        ESgep :-> ipv1, ESgAw :-> ipv2, ESgGI :-> co, ESgL5 :-> n1,
                        ESgLf :-> xs, ESgPD :-> irred, ESgPF :-> irred1, EShqy :-> s1,
                        EShvV :-> m1, EShxS :-> f1, ESjIm :-> vs, ESjIJ :-> select']
                <no location info>: error:
                    Other error:
                    Failed to load module 'VACC'.
                    
                    Tried to load it from precompiled sources, error was:
                    
                      Internal error: found  module, but could not load it
                    
                    Tried to load it from local sources, error was:
                    
                      Cannot continue after interface file error
```

After digging a little deeper this was "caused" by the [introduction](https://gist.github.com/martijnbastiaan/8c4d6a753487417f3eefaaca388cc403#file-log-diff) of `ipv` in `select`:

https://gist.github.com/martijnbastiaan/8c4d6a753487417f3eefaaca388cc403#file-ghc-9-12-2-hs

Note that I have no idea whether this patch is correct, but it does seem to "solve" my issues on `clash-compiler`. I did try to remove either (but not both) of the `deps` passing, but they both cause the same error.