### PR TITLE
Clean up CPP error strings

### DIFF
--- a/tests/ErrorTests.hs
+++ b/tests/ErrorTests.hs
@@ -195,24 +195,7 @@ testProxy10 :: Proxy (a :: Nat) -> Proxy (a + 2) -> ()
 testProxy10 = proxyInEq'
 
 testProxy10Errors =
-#if __GLASGOW_HASKELL__ >= 912
-  [$(do localeEncoding <- runIO (getLocaleEncoding)
-        if textEncodingName localeEncoding == textEncodingName utf8
-          then litE $ stringL "Couldn't match type ‘Data.Type.Ord.OrdCond"
-          else litE $ stringL "Couldn't match type `Data.Type.Ord.OrdCond"
-    )
-  ,$(do localeEncoding <- runIO (getLocaleEncoding)
-        if textEncodingName localeEncoding == textEncodingName utf8
-          then litE $ stringL "(CmpNat a (a + 2)) True True False’"
-          else litE $ stringL "(CmpNat a (a + 2)) True True False'"
-    )
-  ,$(do localeEncoding <- runIO (getLocaleEncoding)
-        if textEncodingName localeEncoding == textEncodingName utf8
-          then litE $ stringL "with ‘False"
-          else litE $ stringL "with `False"
-    )
-  ]
-#elif __GLASGOW_HASKELL__ >= 910
+#if __GLASGOW_HASKELL__ >= 910
   [$(do localeEncoding <- runIO (getLocaleEncoding)
         if textEncodingName localeEncoding == textEncodingName utf8
           then litE $ stringL "Couldn't match type ‘Data.Type.Ord.OrdCond"
@@ -355,24 +338,7 @@ testProxy14 :: Proxy (2*a) -> Proxy (4*a) -> ()
 testProxy14 = proxyInEq'
 
 testProxy14Errors =
-#if __GLASGOW_HASKELL__ >= 912
-  [$(do localeEncoding <- runIO (getLocaleEncoding)
-        if textEncodingName localeEncoding == textEncodingName utf8
-          then litE $ stringL "Couldn't match type ‘Data.Type.Ord.OrdCond"
-          else litE $ stringL "Couldn't match type `Data.Type.Ord.OrdCond"
-    )
-  ,$(do localeEncoding <- runIO (getLocaleEncoding)
-        if textEncodingName localeEncoding == textEncodingName utf8
-          then litE $ stringL "(CmpNat (2 * a) (4 * a)) True True False’"
-          else litE $ stringL "(CmpNat (2 * a) (4 * a)) True True False'"
-    )
-  ,$(do localeEncoding <- runIO (getLocaleEncoding)
-        if textEncodingName localeEncoding == textEncodingName utf8
-          then litE $ stringL "with ‘False"
-          else litE $ stringL "with `False"
-    )
-  ]
-#elif __GLASGOW_HASKELL__ >= 910
+#if __GLASGOW_HASKELL__ >= 910
   [$(do localeEncoding <- runIO (getLocaleEncoding)
         if textEncodingName localeEncoding == textEncodingName utf8
           then litE $ stringL "Couldn't match type ‘Data.Type.Ord.OrdCond"


### PR DESCRIPTION
The 9.12 and 9.10 strings are the same, so no need for the 9.12 lines.