### PR TITLE
Improvements to unification

### DIFF
--- a/ghc-typelits-natnormalise.cabal
+++ b/ghc-typelits-natnormalise.cabal
@@ -5,36 +5,36 @@ synopsis:            GHC typechecker plugin for types of kind GHC.TypeLits.Nat
 description:
   A type checker plugin for GHC that can solve /equalities/ and /inequalities/
   of types of kind @Nat@, where these types are either:
-  .
+
   * Type-level naturals
-  .
+
   * Type variables
-  .
+
   * Applications of the arithmetic expressions @(+,-,*,^)@.
-  .
+
   It solves these equalities by normalising them to /sort-of/ @SOP@
   (Sum-of-Products) form, and then perform a simple syntactic equality.
-  .
+
   For example, this solver can prove the equality between:
-  .
+
   @
   (x + 2)^(y + 2)
   @
-  .
+
   and
-  .
+
   @
   4*x*(2 + x)^y + 4*(2 + x)^y + (2 + x)^y*x^2
   @
-  .
+
   Because the latter is actually the @SOP@ normal form of the former.
-  .
+
   To use the plugin, add the
-  .
+
   @
   OPTIONS_GHC -fplugin GHC.TypeLits.Normalise
   @
-  .
+
   Pragma to the header of your file.
 homepage:            http://www.clash-lang.org/
 bug-reports:         http://github.com/clash-lang/ghc-typelits-natnormalise/issues

--- a/src/GHC/TypeLits/Normalise.hs
+++ b/src/GHC/TypeLits/Normalise.hs
@@ -657,6 +657,13 @@ toNatEquality tcs givensTyConSubst ct0
   = case classifyPredType pred0 of
       EqPred NomEq t1 t2
         -> goNomEq t1 t2
+      ClassPred kn [x]
+        -- From [G] KnownNat blah, also produce [G] 0 <= blah
+        -- See https://github.com/clash-lang/ghc-typelits-natnormalise/issues/94.
+        | isGiven (ctEvidence ct0)
+        , className kn == knownNatClassName
+        , let ((x', cos0), ks) = runWriter (normaliseNat givensTyConSubst x)
+        -> [(Right (ct0, (S [], x', True)), ks, cos0)]
       _ -> []
   where
     pred0 = ctPred ct0

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -728,7 +728,14 @@ t1 _ = ()
 t2 :: ((m1 + n1) ~ (m2 + n2)) => Proxy '(m1, n1, m2, n2) -> ()
 t2 px = t1 px
 
+-- Test for https://github.com/clash-lang/ghc-typelits-natnormalise/issues/94
+t94 ::
+  (KnownNat n, KnownNat m, KnownNat s, s ~ (m - n)) =>
+  Proxy m -> Proxy n -> Proxy (s + 2) -> Proxy (s + 2)
+t94 _ _ = t94_aux
 
+t94_aux :: (1 <= n) => Proxy n -> Proxy n
+t94_aux px = px
 
 type family TF (a :: Nat) (b :: Nat) :: Nat
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -363,7 +363,7 @@ proxyEq3
    . ((x + 1) ~ (2 * y), 1 <= y)
   => Proxy x
   -> Proxy y
-  -> Proxy (((2 * (y - 1)) + 1))
+  -> Proxy ((2 * (y - 1)) + 1)
   -> Proxy x
 proxyEq3 _ _ x = x
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -737,6 +737,14 @@ t94 _ _ = t94_aux
 t94_aux :: (1 <= n) => Proxy n -> Proxy n
 t94_aux px = px
 
+-- Test for https://github.com/clash-lang/ghc-typelits-natnormalise/issues/96
+t96
+  :: ( 2 <= x, 2 <= y
+     , ( 4 * x + 2 * 2^y ) ~ ( 4 * y + 2 * 2^x )
+     )
+  => Proxy x -> Proxy y
+t96 x = x
+
 type family TF (a :: Nat) (b :: Nat) :: Nat
 
 proxyEq5
@@ -754,3 +762,22 @@ proxyEq5 = theProxy
     -> Proxy b
     -> Proxy (3 * TF (3 * a) b)
   theProxy _ _ = Proxy
+
+type family Rank sh where
+  Rank '[] = 0
+  Rank (_ : sh) = Rank sh + 1
+foo :: ( ( 1 + Rank sh ) ~ ( 1 + n ) )
+    => Proxy sh -> Proxy n -> Proxy (Rank sh) -> Proxy n
+foo _ _ px = px
+
+-- Test for https://github.com/clash-lang/ghc-typelits-natnormalise/issues/97
+t97 :: ( (1 + n) ~ m, ( m - 1 ) ~ n ) => Proxy m -> Proxy n -> ()
+t97  _ _ = ()
+
+t97b
+  :: ( n ~ (m - 2)
+     , (n + 1) ~ (m - 1)
+     , m ~ (n + 2)
+     )
+  => Proxy n -> Proxy m -> ()
+t97b _ _ = ()


### PR DESCRIPTION
This fixes #94 and #96, with several changes:

  1. Extract `[G] 0 <= ty` from `[G] KnownNat ty` in `toNatEquality`.
  2. Improve `sopToIneq` to a function which moves terms with negative coefficients to the other side.
      This allows us to properly simplify a constraint like `1 <= 1 + m - n`.
  3. Several improvements to the unification code:
     - When an equality only contains two free variables, try separating the variables on either side of the equality (if that is possible). This fixes #96, although it is very very heuristic.  
     - Allow unifiers to return "definitely apart". This allows us to report contradictions more often, which in theory improves pattern match warnings. Not in practice, because currently GHC doesn't even run typechecker plugins in pattern-match checking, due to bug [#26395](https://gitlab.haskell.org/ghc/ghc/-/issues/26395).

(1) and (2) are needed together to fix #94.