### PR TITLE
 Fix solving constraints involving type families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 * Fixes [#116](https://github.com/clash-lang/ghc-typelits-natnormalise/issues/113) Compile-time loop when processing Given constraints.
+* Fixes [#119](https://github.com/clash-lang/ghc-typelits-natnormalise/issues/119) solving constraints involving type families applied to normalised Nat expressions (e.g. `Foo (a + b)`).
+
 
 ## 0.9.3 *December 2nd 2025*
 * Fixes [#114](https://github.com/clash-lang/ghc-typelits-natnormalise/issues/113) Poor error message in plugin version 0.8 and higher

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -37,7 +37,7 @@ import qualified Prelude as P
 import Data.Type.Ord
 #endif
 
-import Data.Kind (Type)
+import Data.Kind (Type, Constraint)
 import Data.List (isInfixOf)
 import Data.Proxy
 import Data.Type.Equality ((:~:)(..))
@@ -810,3 +810,24 @@ t116 a b c =
           case c of
             Refl ->
               3.0
+
+type family Foo (n :: Nat) :: Nat
+
+t119a :: Proxy n -> Proxy (Foo (n + 2)) -> Proxy (Foo (2 + n))
+t119a _ = id
+
+--Only applicable for GHC >= 9.4 as prior InEq constraints are of the form `a <=? b ~ 'True`
+#if __GLASGOW_HASKELL__ >= 904
+t119b ::
+  (1 <= a) =>
+  (1 <= Foo (a + 1)) =>
+  Proxy a ->
+  Proxy a
+t119b a = go a
+  where
+    go ::
+      ((1 <= Foo (c + 1)) ~ (() :: Constraint)) =>
+      Proxy c ->
+      Proxy c
+    go _ = Proxy
+#endif


### PR DESCRIPTION
 applied to normalised Nat expressions (e.g. `Foo (a + b)`).
 
 Fixes https://github.com/clash-lang/ghc-typelits-extra/issues/68