### PR TITLE
Use a finer criterion to determine whether a Given actually constitutes new evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for the [`ghc-typelits-natnormalise`](http://hackage.haskell.org/package/ghc-typelits-natnormalise) package
 
+## Unreleased
+* Fixes [#116](https://github.com/clash-lang/ghc-typelits-natnormalise/issues/113) Compile-time loop when processing Given constraints.
+
 ## 0.9.3 *December 2nd 2025*
 * Fixes [#114](https://github.com/clash-lang/ghc-typelits-natnormalise/issues/113) Poor error message in plugin version 0.8 and higher
 * Fixes [#113](https://github.com/clash-lang/ghc-typelits-natnormalise/issues/113) Wanted contraints rewrites to itself, leading to infinite solver iterations

--- a/ghc-typelits-natnormalise.cabal
+++ b/ghc-typelits-natnormalise.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                ghc-typelits-natnormalise
-version:             0.9.3
+version:             0.9.4
 synopsis:            GHC typechecker plugin for types of kind GHC.TypeLits.Nat
 description:
   A type checker plugin for GHC that can solve /equalities/ and /inequalities/
@@ -70,7 +70,7 @@ library
   build-depends:       base                >=4.9   && <5,
                        containers          >=0.5.7.1 && <0.9,
                        ghc                 >=8.8.1 && <9.15,
-                       ghc-tcplugin-api    >=0.18.0 && <0.19,
+                       ghc-tcplugin-api    >=0.18.2 && <0.19,
                        transformers        >=0.5.2.0 && < 0.7
   if impl(ghc >= 9.0.0)
     build-depends:     ghc-bignum >=1.0 && <1.5

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -40,6 +40,7 @@ import Data.Type.Ord
 import Data.Kind (Type)
 import Data.List (isInfixOf)
 import Data.Proxy
+import Data.Type.Equality ((:~:)(..))
 import Control.Exception
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -798,3 +799,14 @@ t97b
      )
   => Proxy n -> Proxy m -> ()
 t97b _ _ = ()
+
+-- Test for https://github.com/clash-lang/ghc-typelits-natnormalise/issues/116
+t116 :: forall n m l. m :~: n -> n :~: 0 -> l :~: 1 -> Float
+t116 a b c =
+  case a of
+    Refl ->
+      case b of
+        Refl ->
+          case c of
+            Refl ->
+              3.0


### PR DESCRIPTION
This PR shores up the logic for determining whether a new Given is in fact implied by pre-existing Givens, by computing a fix-point substitution from the Givens to determine whether the candidate new Given is actually new or just a reformulation of what we already knew.

This avoids GHC falling into a loop because of the plugin constantly re-emitting the same Given.

Fixes #116