### PR TITLE
Emit `0 <= F x` instead of `KnownNat (F x)`

### DIFF
--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -486,6 +486,20 @@ proxyInEq8
   -> Proxy n
 proxyInEq8 = proxyInEq8fun
 
+type family Stuck (n :: Nat) :: Nat
+
+proxyInEqStuckNatFun
+  :: 1 <= (1 + Stuck a)
+  => Proxy n
+  -> Proxy n
+proxyInEqStuckNatFun = id
+
+proxyInEqStuckNat
+  :: KnownNat (Stuck n)
+  => Proxy n
+  -> Proxy n
+proxyInEqStuckNat = proxyInEqStuckNatFun
+
 data H2 = H2 { p :: Nat }
 
 class Q (dom :: Symbol) where


### PR DESCRIPTION
to ensure later on `F x` is really a Nat.

Alternate to https://github.com/clash-lang/ghc-typelits-natnormalise/pull/122 for fixing https://github.com/clash-lang/ghc-typelits-knownnat/issues/68