### PR TITLE
Add support for GHC 10.2

### DIFF
--- a/ghc-typelits-natnormalise.cabal
+++ b/ghc-typelits-natnormalise.cabal
@@ -70,8 +70,8 @@ library
                        GHC.TypeLits.Normalise.Unify
   build-depends:       base                >=4.9   && <5,
                        containers          >=0.5.7.1 && <0.9,
-                       ghc                 >=8.8.1 && <9.15,
-                       ghc-tcplugin-api    >=0.19 && <0.20,
+                       ghc                 >=8.8.1 && <10.3,
+                       ghc-tcplugin-api    >=0.20.1 && <0.21,
                        transformers        >=0.5.2 && < 0.7
   if impl(ghc >= 9.0.0)
     build-depends:     ghc-bignum >=1.0 && <1.5
@@ -80,9 +80,7 @@ library
 
     mixins:
       ghc
-        ( TcTypeNats as GHC.Builtin.Types.Literals
-        , TyCon      as GHC.Core.TyCon
-        , TysWiredIn as GHC.Builtin.Types
+        ( TyCon      as GHC.Core.TyCon
         , Unique     as GHC.Types.Unique
         , Util       as GHC.Utils.Misc
         )

--- a/src/GHC/TypeLits/Normalise.hs
+++ b/src/GHC/TypeLits/Normalise.hs
@@ -192,16 +192,14 @@ import qualified Data.Map.Strict as Map
   ( empty, insertWith, traverseWithKey )
 
 -- ghc
-import GHC.Builtin.Names
-  ( knownNatClassName )
-import GHC.Builtin.Types.Literals
-  ( typeNatAddTyCon, typeNatExpTyCon, typeNatMulTyCon, typeNatSubTyCon )
 import GHC.Core.TyCon
   ( Injectivity (..), tyConInjectivityInfo, tyConArity )
 import GHC.Utils.Misc
   ( filterByList )
 
 -- ghc-tcplugin-api
+import GHC.Builtins
+  ( typeNatAddTyCon, typeNatExpTyCon, typeNatMulTyCon, typeNatSubTyCon )
 import GHC.TcPlugin.API
 import GHC.TcPlugin.API.TyConSubst
   ( TyConSubst, mkTyConSubst )
@@ -368,7 +366,7 @@ decideEqualSOP opts (ExtraDefs { tyCons = tcs }) givens wanteds0 = do
     (redGivens, negWanteds) <- reduceGivens True opts tcs givens
     reducible_wanteds
       <- catMaybes <$> mapM (\ct -> fmap (ct,) <$>
-                                    reduceNatConstr redGivens ct)
+                                    reduceNatConstr tcs redGivens ct)
                             nonEqs
 
     tcPluginTrace "decideEqualSOP Wanteds {" $
@@ -471,8 +469,8 @@ fromNatEquality :: Either NatEquality NatInEquality -> Ct
 fromNatEquality (Left  (ct, _, _)) = ct
 fromNatEquality (Right (ct, _))    = ct
 
-reduceNatConstr :: [Ct] -> Ct -> TcPluginM Solve (Maybe (EvTerm, [(Type, Type)], [Ct]))
-reduceNatConstr givens ct = do
+reduceNatConstr :: LookedUpTyCons -> [Ct] -> Ct -> TcPluginM Solve (Maybe (EvTerm, [(Type, Type)], [Ct]))
+reduceNatConstr tcs givens ct = do
   let pred0 = ctEvPred $ ctEvidence ct
       (mans, tests) = runWriter $ normaliseNatEverywhere pred0
 
@@ -483,7 +481,7 @@ reduceNatConstr givens ct = do
     -- No existing evidence found
     Nothing
       | ClassPred cls _ <- classifyPredType pred'
-      , className cls /= knownNatClassName
+      , cls /= knownNatClass tcs
 
       -- We actually did do some rewriting/normalisation.
       , Just {} <- mans
@@ -829,7 +827,7 @@ toNatEquality opts tcs givensTyConSubst ct0
         -- From [G] KnownNat blah, also produce [G] 0 <= blah
         -- See https://github.com/clash-lang/ghc-typelits-natnormalise/issues/94.
         | isGiven (ctEvidence ct0)
-        , className kn == knownNatClassName
+        , kn == knownNatClass tcs
         , let ((x', cos0), ks) = runWriter (normaliseNat x)
         , let preds = subToPred opts tcs ks
         -> [NatCt (Right (ct0, (S [], x', True))) preds cos0]
@@ -942,7 +940,7 @@ evMagic ::
   TcPluginM Solve (Maybe ((EvTerm, Ct), [Ct]))
 evMagic tcs ct deps knW preds = do
   holeWanteds <- evSubtPreds (ctLoc ct) preds
-  knWanted <- mapM (mkKnWanted (ctLoc ct)) (Set.elems knW)
+  knWanted <- mapM (mkKnWanted tcs (ctLoc ct)) (Set.elems knW)
   let newWant = knWanted ++ holeWanteds
   case classifyPredType $ ctEvPred $ ctEvidence ct of
     EqPred NomEq t1 t2 ->
@@ -956,11 +954,11 @@ evMagic tcs ct deps knW preds = do
     _ -> return Nothing
 
 mkKnWanted
-  :: CtLoc
+  :: LookedUpTyCons
+  -> CtLoc
   -> CType
   -> TcPluginM Solve Ct
-mkKnWanted loc (CType ty) = do
-  kc_clas <- tcLookupClass knownNatClassName
-  let kn_pred = mkClassPred kc_clas [ty]
+mkKnWanted tcs loc (CType ty) = do
+  let kn_pred = mkClassPred (knownNatClass tcs) [ty]
   wantedCtEv <- newWanted loc kn_pred
   return $ mkNonCanonical wantedCtEv

--- a/src/GHC/TypeLits/Normalise/Compat.hs
+++ b/src/GHC/TypeLits/Normalise/Compat.hs
@@ -35,7 +35,7 @@ import qualified Data.List.NonEmpty as NE
 import Data.Foldable
   ( asum )
 import GHC.TypeNats
-  ( CmpNat )
+  ( CmpNat, KnownNat )
 #if MIN_VERSION_ghc(9,3,0)
 import qualified GHC.TypeError
   ( Assert )
@@ -50,18 +50,6 @@ import GHC.TypeNats
 #endif
 
 -- ghc
-import GHC.Builtin.Types
-  ( isCTupleTyConName
-  , promotedFalseDataCon, promotedTrueDataCon
-  , promotedLTDataCon, promotedEQDataCon, promotedGTDataCon
-  )
-#if MIN_VERSION_ghc(9,1,0)
-import GHC.Builtin.Types
-  ( cTupleTyCon, cTupleDataCon )
-#else
-import GHC.Builtin.Types
-  ( cTupleTyConName )
-#endif
 #if MIN_VERSION_ghc(9,7,0)
 import GHC.Types.Unique.Map
   ( UniqMap, intersectUniqMap_C, listToUniqMap, nonDetUniqMapToList )
@@ -73,6 +61,16 @@ import GHC.Types.Unique.FM
 #endif
 
 -- ghc-tcplugin-api
+import GHC.Builtins
+  ( isCTupleTyConName
+  , promotedFalseDataCon, promotedTrueDataCon
+  , promotedLTDataCon, promotedEQDataCon, promotedGTDataCon
+#if MIN_VERSION_ghc(9,1,0)
+  , cTupleTyCon, cTupleDataCon
+#else
+  , cTupleTyConName
+#endif
+  )
 import GHC.TcPlugin.API
 import GHC.TcPlugin.API.TyConSubst
   ( TyConSubst, splitTyConApp_upTo )
@@ -97,12 +95,15 @@ data LookedUpTyCons
 #endif
       cmpNatTyCon :: TyCon,
       c0TyCon   :: TyCon,
-      c0DataCon :: DataCon
+      c0DataCon :: DataCon,
+      -- | @KnownNat :: Nat -> Constraint@
+      knownNatClass :: Class
     }
 
 lookupTyCons :: TcPluginM Init LookedUpTyCons
 lookupTyCons = do
     cmpNatT <- lookupTHName ''GHC.TypeNats.CmpNat >>= tcLookupTyCon
+    knownNatC <- lookupTHName ''GHC.TypeNats.KnownNat >>= tcLookupClass
 #if MIN_VERSION_ghc(9,3,0)
     assertT <- lookupTHName ''GHC.TypeError.Assert >>= tcLookupTyCon
 #endif
@@ -119,6 +120,7 @@ lookupTyCons = do
         , cmpNatTyCon  = cmpNatT
         , c0TyCon      = cTupleTyCon 0
         , c0DataCon    = cTupleDataCon 0
+        , knownNatClass = knownNatC
         }
 #else
     leqT  <- lookupTHName ''(GHC.TypeNats.<=)  >>= tcLookupTyCon
@@ -134,6 +136,7 @@ lookupTyCons = do
         , c0TyCon      = c0T
         , c0DataCon    = c0D
         , cmpNatTyCon  = cmpNatT
+        , knownNatClass = knownNatC
         }
 #endif
 

--- a/src/GHC/TypeLits/Normalise/Unify.hs
+++ b/src/GHC/TypeLits/Normalise/Unify.hs
@@ -69,9 +69,6 @@ import Data.Set
 import qualified Data.Set as Set
 
 -- ghc
-import GHC.Builtin.Types.Literals
-  ( typeNatAddTyCon, typeNatExpTyCon, typeNatMulTyCon, typeNatSubTyCon
-  )
 import GHC.Types.Unique.Set
   ( UniqSet
   , emptyUniqSet, unionManyUniqSets, unionUniqSets, unitUniqSet
@@ -79,6 +76,9 @@ import GHC.Types.Unique.Set
   )
 
 -- ghc-tcplugin-api
+import GHC.Builtins
+  ( typeNatAddTyCon, typeNatExpTyCon, typeNatMulTyCon, typeNatSubTyCon
+  )
 import GHC.TcPlugin.API
 import GHC.Utils.Outputable
 


### PR DESCRIPTION
This patch adapts to the changes to known entities that will land in GHC 10.2. Needs `ghc-tcplugin-api-0.20.1.0` which I just released.